### PR TITLE
Respect the api version that is being set in the ConfigurationVO

### DIFF
--- a/src/MastodonAPI.php
+++ b/src/MastodonAPI.php
@@ -53,7 +53,7 @@ class MastodonAPI
     private function getResponse(string $endpoint, string $method, array $json, bool $authenticate = true): mixed
     {
         $uri = $this->config->getBaseUrl() . '/api/';
-        $uri .= ConfigurationVO::API_VERSION . $endpoint;
+        $uri .= $this->config->apiVersion . $endpoint;
 
         $allowedMethods = array_column(HttpOperation::cases(), 'name');
         if (!in_array($method, $allowedMethods)) {

--- a/src/MastodonOAuth.php
+++ b/src/MastodonOAuth.php
@@ -22,10 +22,12 @@ class MastodonOAuth
      * Creates the OAuth object from the configuration.
      */
     public function __construct(
-        $client_name = ConfigurationVO::DEFAULT_NAME,
-        $mastodon_instance = ConfigurationVO::DEFAULT_INSTANCE
+        string $client_name = ConfigurationVO::DEFAULT_NAME,
+        string $mastodon_instance = ConfigurationVO::DEFAULT_INSTANCE,
+        string $redirectUris = ConfigurationVO::DEFAULT_REDIRECT_URIS,
+        string $api_version = ConfigurationVO::API_VERSION
     ) {
-        $this->config = new ConfigurationVO($client_name, $mastodon_instance);
+        $this->config = new ConfigurationVO($client_name, $mastodon_instance, $redirectUris, $api_version);
         $this->client = new Client();
     }
 


### PR DESCRIPTION
## What happened?

I was creating a ConfigurationVO object and I was setting the `$apiVersion` parameter to `v2`. When I then used the `MastodonAPI` object that I can created using the ConfigurationVO object, when I called (in my case) the `/search` endpoint, I got a 404 error from the API, because it was trying to call `/api/v1/search`. It did not respect the `v2` I had set because the code was using the `ConfigurationVO::API_VERSION` constant, which is set to `v1`.

## The solution

Instead of using the constant from the ConfigurationVO class, I use the `$apiVersion` property of the `$this->config` instead of the VO. Now, when I call the `getPublicData('/search')`, it respects the version and calls the `v2` API.